### PR TITLE
Removes self assign permissions from subscriber badge

### DIFF
--- a/plugins/subscriber/index.js
+++ b/plugins/subscriber/index.js
@@ -4,7 +4,7 @@ module.exports = {
       name: 'SUBSCRIBER',
       permissions: {
         public: true,
-        self: true,
+        self: false,
         roles: []
       },
       models: ['USERS'],


### PR DESCRIPTION
Fixes issue where a user could technically add the tag themselves via the API.